### PR TITLE
Add note about bfcache iframe eligibility

### DIFF
--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -362,7 +362,8 @@ As a result, it's best to avoid creating `window.opener` references. You can do 
 controlling it through
 [`window.postMessage()`](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 or directly referencing the window object, neither the opened window nor the
-opener will be eligible for the bfcache.
+opener will be eligible for the bfcache. For the same reason, pages loaded into an `iframe`
+are also not eligible for the bfcache.
 
 ### Always close open connections before the user navigates away
 


### PR DESCRIPTION
It looks like iframes aren't added to bfcache, and I wasn't able to find any pages documenting that. This seems like a roughly correct place.

Open to alternative places, feel free to reject this.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- Due to an upcoming migration of this site we are no longer merging pull requests for changes to existing content. Please raise content issues at https://issuetracker.google.com/issues/new?component=1400680&pli=1&template=1857359  -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Add note about iframe bfcache eligibility.
-
-

